### PR TITLE
Actually use the async code paths for bulk insert

### DIFF
--- a/src/PhenX.EntityFrameworkCore.BulkInsert/BulkInsertProviderBase.cs
+++ b/src/PhenX.EntityFrameworkCore.BulkInsert/BulkInsertProviderBase.cs
@@ -144,7 +144,7 @@ internal abstract class BulkInsertProviderBase<TDialect, TOptions>(ILogger? logg
         activity?.AddTag("tempTable", tempTableRequired);
         activity?.AddTag("synchronous", sync);
 
-        await BulkInsert(false, context, tableInfo, entities, tableName, columns, options, ctk);
+        await BulkInsert(sync, context, tableInfo, entities, tableName, columns, options, ctk);
         return tableName;
     }
 


### PR DESCRIPTION
Since its introduction in 045033c26e3d6cb4c2d989af70d72bfe592a5465, the `sync` argument passed to `BulkInsert()` has always been hardcoded to `false` instead of forwarding the `sync` parameter.

As a result, the async code paths for bulk insert in all providers would never be used. This can be confirmed by running code coverage.