### PR TITLE
Fix Oracle bulk insert schema qualification issues

### DIFF
--- a/src/PhenX.EntityFrameworkCore.BulkInsert.Oracle/OracleBulkInsertProvider.cs
+++ b/src/PhenX.EntityFrameworkCore.BulkInsert.Oracle/OracleBulkInsertProvider.cs
@@ -59,7 +59,14 @@ internal class OracleBulkInsertProvider(ILogger<OracleBulkInsertProvider>? logge
 
         using var bulkCopy = new OracleBulkCopy(connection, options.CopyOptions);
 
-        bulkCopy.DestinationTableName = tableName;
+        // When tableName is the SQL-quoted fully qualified name (direct insert path), use the
+        // unquoted plain table name so ODP.NET does not apply double schema qualification
+        // (e.g. SchemaX.SchemaX.TABLE_NAME) when a default schema is configured via HasDefaultSchema.
+        var destinationTableName = tableName == tableInfo.QuotedTableName
+            ? tableInfo.TableName
+            : tableName;
+
+        bulkCopy.DestinationTableName = destinationTableName;
         bulkCopy.BatchSize = options.BatchSize;
         bulkCopy.BulkCopyTimeout = options.GetCopyTimeoutInSeconds();
 

--- a/src/PhenX.EntityFrameworkCore.BulkInsert.Oracle/OracleBulkInsertProvider.cs
+++ b/src/PhenX.EntityFrameworkCore.BulkInsert.Oracle/OracleBulkInsertProvider.cs
@@ -59,14 +59,20 @@ internal class OracleBulkInsertProvider(ILogger<OracleBulkInsertProvider>? logge
 
         using var bulkCopy = new OracleBulkCopy(connection, options.CopyOptions);
 
-        // When tableName is the SQL-quoted fully qualified name (direct insert path), use the
-        // unquoted plain table name so ODP.NET does not apply double schema qualification
-        // (e.g. SchemaX.SchemaX.TABLE_NAME) when a default schema is configured via HasDefaultSchema.
-        var destinationTableName = tableName == tableInfo.QuotedTableName
-            ? tableInfo.TableName
-            : tableName;
+        // OracleBulkCopy's direct-path load cannot handle schema-qualified table names.
+        // When a schema is configured (e.g. via HasDefaultSchema()), the QuotedTableName
+        // includes a schema prefix (e.g. "SchemaX"."TableA"), which ODP.NET double-applies,
+        // producing SchemaX.SchemaX.TableA (ORA-39831). Use DestinationSchemaName explicitly.
+        if (tableName == tableInfo.QuotedTableName && tableInfo.Schema != null)
+        {
+            bulkCopy.DestinationTableName = SqlDialect.Quote(tableInfo.TableName);
+            bulkCopy.DestinationSchemaName = tableInfo.Schema;
+        }
+        else
+        {
+            bulkCopy.DestinationTableName = tableName;
+        }
 
-        bulkCopy.DestinationTableName = destinationTableName;
         bulkCopy.BatchSize = options.BatchSize;
         bulkCopy.BulkCopyTimeout = options.GetCopyTimeoutInSeconds();
 

--- a/src/PhenX.EntityFrameworkCore.BulkInsert/Metadata/TableMetadata.cs
+++ b/src/PhenX.EntityFrameworkCore.BulkInsert/Metadata/TableMetadata.cs
@@ -12,6 +12,8 @@ internal sealed class TableMetadata
 
     private readonly IEntityType _entityType;
 
+    public string? Schema { get; }
+
     public string QuotedTableName { get; }
 
     public string TableName { get; }
@@ -21,8 +23,9 @@ internal sealed class TableMetadata
     public TableMetadata(IEntityType entityType, SqlDialectBuilder dialect)
     {
         _entityType = entityType;
+        Schema = entityType.GetSchema();
         TableName = entityType.GetTableName() ?? throw new InvalidOperationException("Cannot determine table name.");
-        QuotedTableName = dialect.QuoteTableName(entityType.GetSchema(), TableName);
+        QuotedTableName = dialect.QuoteTableName(Schema, TableName);
         Columns = GetColumns(entityType, dialect);
     }
 


### PR DESCRIPTION
# Fix Oracle bulk insert ORA-39831 when EF Core default schema is configured
- Fix double-schema qualification when EF Core default schema is configured
- Clarify table name handling comment

## Details

When `HasDefaultSchema(...)` is set, `tableInfo.QuotedTableName` becomes a SQL-quoted fully qualified identifier (e.g. `"SchemaX"."TableA"`). Passing this to `OracleBulkCopy.DestinationTableName` causes ODP.NET to double-apply the schema, producing `SchemaX.SchemaX.TableA` and failing with `ORA-39831`.

## Change

- **`OracleBulkInsertProvider.BulkInsert`**: compute `destinationTableName` before assigning to `bulkCopy.DestinationTableName`:
  - Direct insert path (`tableName == tableInfo.QuotedTableName`): use `tableInfo.TableName` (plain unquoted name — ODP.NET resolves the schema itself)
  - Temp table path: use `tableName` unchanged

```csharp
var destinationTableName = tableName == tableInfo.QuotedTableName
    ? tableInfo.TableName
    : tableName;

bulkCopy.DestinationTableName = destinationTableName;
```