### PR TITLE
WIP: test for array content getting lost when using `.HasDefaultValueSql("'{}'")`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,8 @@ fabric.properties
 # Vitepress
 docs/.vitepress/dist
 docs/.vitepress/cache
+
+.direnv
+.envrc
+.launch
+PhenX.EntityFrameworkCore.BulkInsert.sln.DotSettings.user

--- a/tests/PhenX.EntityFrameworkCore.BulkInsert.Tests/DbContainer/TestDbContainer.cs
+++ b/tests/PhenX.EntityFrameworkCore.BulkInsert.Tests/DbContainer/TestDbContainer.cs
@@ -30,7 +30,7 @@ public abstract class TestDbContainer<TBuilderEntity, TContainerEntity>(IMessage
     {
         var targetFramework = GetType().Assembly.GetCustomAttributes<AssemblyMetadataAttribute>().FirstOrDefault(e => e.Key == "TargetFramework")?.Value ?? "NA";
         return CreateBuilder()
-            .WithReuse(true)
+            .WithReuse(false)
             .WithName($"PhenX.EntityFrameworkCore.BulkInsert.Tests.{DbmsName}-{targetFramework}")
             .WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
     }

--- a/tests/PhenX.EntityFrameworkCore.BulkInsert.Tests/DbContainer/TestDbContainer.cs
+++ b/tests/PhenX.EntityFrameworkCore.BulkInsert.Tests/DbContainer/TestDbContainer.cs
@@ -24,7 +24,7 @@ public abstract class TestDbContainer<TBuilderEntity, TContainerEntity>(IMessage
 
     protected abstract TBuilderEntity CreateBuilder();
 
-    protected virtual string DbmsName => typeof(TContainerEntity).Name.Replace("Container", "");
+    protected virtual string DbmsName => GetType().Name.Replace("TestDbContainer", "");
 
     protected override TBuilderEntity Configure()
     {

--- a/tests/PhenX.EntityFrameworkCore.BulkInsert.Tests/DbContainer/TestDbContainerPostgreSqlSnakeCase.cs
+++ b/tests/PhenX.EntityFrameworkCore.BulkInsert.Tests/DbContainer/TestDbContainerPostgreSqlSnakeCase.cs
@@ -1,0 +1,39 @@
+using System.Data.Common;
+
+using Microsoft.EntityFrameworkCore;
+
+using Npgsql;
+
+using PhenX.EntityFrameworkCore.BulkInsert.PostgreSql;
+
+using Testcontainers.PostgreSql;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PhenX.EntityFrameworkCore.BulkInsert.Tests.DbContainer;
+
+[CollectionDefinition(Name)]
+public class TestDbContainerPostgreSqlSnakeCaseCollection : ICollectionFixture<TestDbContainerPostgreSqlSnakeCase>
+{
+    public const string Name = "PostgreSqlSnakeCase";
+}
+
+public class TestDbContainerPostgreSqlSnakeCase(IMessageSink messageSink) : TestDbContainer<PostgreSqlBuilder, PostgreSqlContainer>(messageSink)
+{
+    public override DbProviderFactory DbProviderFactory => NpgsqlFactory.Instance;
+
+    // GeoSpatial support, using imresamu/postgis instead of postgis/postgis for arm64 support, see https://github.com/postgis/docker-postgis/issues/216#issuecomment-2936824962
+    protected override PostgreSqlBuilder CreateBuilder() => new("imresamu/postgis:17-3.5");
+
+    protected override void Configure(DbContextOptionsBuilder optionsBuilder, string databaseName)
+    {
+        optionsBuilder
+            .UseNpgsql(GetConnectionString(databaseName), o =>
+            {
+                o.UseNetTopologySuite();
+            })
+            .UseSnakeCaseNamingConvention()
+            .UseBulkInsertPostgreSql();
+    }
+}

--- a/tests/PhenX.EntityFrameworkCore.BulkInsert.Tests/DbContext/TestDbContext.cs
+++ b/tests/PhenX.EntityFrameworkCore.BulkInsert.Tests/DbContext/TestDbContext.cs
@@ -76,6 +76,8 @@ public class TestDbContextPostgreSql : TestDbContext
     {
         base.OnModelCreating(modelBuilder);
 
+        modelBuilder.Entity<TestEntityWithArrays>().Property(e => e.IntArray).HasDefaultValueSql("'{}'");
+
         modelBuilder.Entity<TestEntityWithJson>(b =>
         {
             b.Property(x => x.JsonArray).AsJsonString("jsonb");

--- a/tests/PhenX.EntityFrameworkCore.BulkInsert.Tests/PhenX.EntityFrameworkCore.BulkInsert.Tests.csproj
+++ b/tests/PhenX.EntityFrameworkCore.BulkInsert.Tests/PhenX.EntityFrameworkCore.BulkInsert.Tests.csproj
@@ -38,18 +38,21 @@
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="8.0.20" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="8.0.11" />
       <PackageReference Include="Pomelo.EntityFrameworkCore.MySql.NetTopologySuite" Version="8.0.3" />
+      <PackageReference Include="EFCore.NamingConventions" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup Label="NetTopologySuite net9.0" Condition="'$(TargetFramework)' == 'net9.0'">
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="9.0.9" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="9.0.4" />
       <PackageReference Include="Microting.EntityFrameworkCore.MySql.NetTopologySuite" Version="9.0.8" />
+      <PackageReference Include="EFCore.NamingConventions" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup Label="NetTopologySuite net10.0" Condition="'$(TargetFramework)' == 'net10.0'">
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="10.0.2" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="10.0.0" />
       <PackageReference Include="Microting.EntityFrameworkCore.MySql.NetTopologySuite" Version="10.0.7" />
+      <PackageReference Include="EFCore.NamingConventions" Version="10.0.1" />
     </ItemGroup>
 
     <ItemGroup Label="Specific dependencies">

--- a/tests/PhenX.EntityFrameworkCore.BulkInsert.Tests/Tests/Arrays/ArrayTestsPostgreSqlSnakeCase.cs
+++ b/tests/PhenX.EntityFrameworkCore.BulkInsert.Tests/Tests/Arrays/ArrayTestsPostgreSqlSnakeCase.cs
@@ -1,0 +1,12 @@
+using PhenX.EntityFrameworkCore.BulkInsert.Tests.DbContainer;
+using PhenX.EntityFrameworkCore.BulkInsert.Tests.DbContext;
+
+using Xunit;
+
+namespace PhenX.EntityFrameworkCore.BulkInsert.Tests.Tests.Arrays;
+
+[Trait("Category", "PostgreSqlSnakeCase")]
+[Collection(TestDbContainerPostgreSqlSnakeCaseCollection.Name)]
+public class ArrayTestsPostgreSqlSnakeCase(TestDbContainerPostgreSqlSnakeCase dbContainer) : ArrayTestsBase<TestDbContextPostgreSql>(dbContainer)
+{
+}


### PR DESCRIPTION
I'm trying out some things here to reproduce the problem from #98 

Seems like content for arrays is lost when that property has `.HasDefaultValueSql("'{}'")`, as I suspected. (that's in the last commit, the other are other stuff I'm trying out)

No idea why.