### PR TITLE
Fix: empty Update expression produces invalid ON CONFLICT / MERGE SQL

### DIFF
--- a/src/PhenX.EntityFrameworkCore.BulkInsert.Oracle/OracleDialectBuilder.cs
+++ b/src/PhenX.EntityFrameworkCore.BulkInsert.Oracle/OracleDialectBuilder.cs
@@ -91,7 +91,17 @@ internal class OracleDialectBuilder : SqlDialectBuilder
             q.AppendJoin(", ", insertedColumns, (b, col) => b.Append($"{PseudoTableExcluded}.{col.QuotedColumName}"));
             q.AppendLine(")");
 
-            if (onConflictTyped.Update != null)
+            // Oracle MERGE: columns in the ON clause cannot be updated, so exclude match columns. Use
+            // insertedColumns because the USING subquery only contains those. When nothing is left to
+            // update — an entity that is nothing but its primary key, or whose Update expression resolves
+            // to no columns — emit an insert-only MERGE (omit the WHEN MATCHED clause) rather than an empty
+            // (illegal) WHEN MATCHED ... UPDATE SET.
+            var matchColumnSet = matchColumns.ToHashSet();
+            var updateableColumns = onConflictTyped.Update != null
+                ? insertedColumns.Where(c => !matchColumnSet.Contains(c.QuotedColumName)).ToList()
+                : new List<ColumnMetadata>();
+
+            if (updateableColumns.Count > 0)
             {
                 q.Append("WHEN MATCHED ");
 
@@ -107,16 +117,6 @@ internal class OracleDialectBuilder : SqlDialectBuilder
                 }
 
                 q.AppendLine("THEN UPDATE SET ");
-                // Oracle MERGE: columns in ON clause cannot be updated, so exclude match columns
-                // Use insertedColumns instead of all columns because the USING subquery only contains insertedColumns
-                var matchColumnSet = matchColumns.ToHashSet();
-                var updateableColumns = insertedColumns.Where(c => !matchColumnSet.Contains(c.QuotedColumName)).ToList();
-                if (updateableColumns.Count == 0)
-                {
-                    throw new InvalidOperationException(
-                        "Oracle MERGE cannot update any columns because all available columns are used in the ON clause for conflict detection. " +
-                        "Specify different columns in the 'Match' option or use specific columns in the 'Update' expression.");
-                }
                 q.AppendJoin(", ", GetUpdates(context, target, updateableColumns, onConflictTyped.Update));
                 q.AppendLine();
             }

--- a/src/PhenX.EntityFrameworkCore.BulkInsert.SqlServer/SqlServerDialectBuilder.cs
+++ b/src/PhenX.EntityFrameworkCore.BulkInsert.SqlServer/SqlServerDialectBuilder.cs
@@ -69,10 +69,15 @@ internal class SqlServerDialectBuilder : SqlDialectBuilder
             q.AppendJoin(" AND ", matchColumns, (b, col) => b.Append($"{PseudoTableInserted}.{col} = {PseudoTableExcluded}.{col}"));
             q.AppendLine();
 
-            if (onConflictTyped.Update != null)
-            {
-                var columns = target.GetColumns(false);
+            // The Update expression can resolve to zero columns (an entity that is nothing but its primary
+            // key). A MERGE with "WHEN MATCHED THEN UPDATE SET" and an empty assignment list is invalid;
+            // with nothing to update, emit an insert-only MERGE (omit the WHEN MATCHED clause entirely).
+            var updates = onConflictTyped.Update != null
+                ? GetUpdates(context, target, target.GetColumns(false), onConflictTyped.Update).ToList()
+                : new List<string>();
 
+            if (updates.Count > 0)
+            {
                 q.AppendLine("WHEN MATCHED ");
 
                 if (onConflictTyped.RawWhere != null || onConflictTyped.Where != null)
@@ -87,7 +92,7 @@ internal class SqlServerDialectBuilder : SqlDialectBuilder
                 }
 
                 q.AppendLine("THEN UPDATE SET ");
-                q.AppendJoin(", ", GetUpdates(context, target, columns, onConflictTyped.Update));
+                q.AppendJoin(", ", updates);
                 q.AppendLine();
             }
 

--- a/src/PhenX.EntityFrameworkCore.BulkInsert/Dialect/SqlDialectBuilder.cs
+++ b/src/PhenX.EntityFrameworkCore.BulkInsert/Dialect/SqlDialectBuilder.cs
@@ -94,15 +94,20 @@ internal abstract class SqlDialectBuilder
         {
             AppendOnConflictStatement(q);
 
-            if (onConflictTyped.Update != null)
+            // An Update expression can resolve to zero columns (e.g. an entity that is nothing but its
+            // primary key, so there is no non-key column to overwrite). Emitting "DO UPDATE SET" with an
+            // empty assignment list is invalid SQL on every provider (PostgreSQL 42601, SQLite "near ;"),
+            // and there is nothing to update on a match anyway, so fall back to DO NOTHING.
+            var updates = onConflictTyped.Update != null
+                ? GetUpdates(context, target, insertedColumns, onConflictTyped.Update).ToList()
+                : new List<string>();
+
+            if (updates.Count > 0)
             {
                 AppendConflictMatch(q, target, onConflictTyped);
 
-                if (onConflictTyped.Update != null)
-                {
-                    q.Append(' ');
-                    AppendOnConflictUpdate(q, GetUpdates(context, target, insertedColumns, onConflictTyped.Update));
-                }
+                q.Append(' ');
+                AppendOnConflictUpdate(q, updates);
 
                 if (onConflictTyped.RawWhere != null || onConflictTyped.Where != null)
                 {

--- a/tests/PhenX.EntityFrameworkCore.BulkInsert.Tests/Tests/Merge/MergeTestsBase.cs
+++ b/tests/PhenX.EntityFrameworkCore.BulkInsert.Tests/Tests/Merge/MergeTestsBase.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
 
+using Microsoft.EntityFrameworkCore;
+
 using PhenX.EntityFrameworkCore.BulkInsert.Enums;
 using PhenX.EntityFrameworkCore.BulkInsert.Extensions;
 using PhenX.EntityFrameworkCore.BulkInsert.Options;
@@ -90,6 +92,44 @@ public abstract class MergeTestsBase<TDbContext>(IDbContextFactory dbContextFact
         // Assert - all fields including the application-assigned Guid Id should be preserved
         insertedEntities.Should().BeEquivalentTo(entities,
             o => o.RespectingRuntimeTypes());
+    }
+
+    [SkippableTheory]
+    [CombinatorialData]
+    public async Task InsertEntities_WithEmptyUpdate_DoesNothingOnConflict(InsertStrategy strategy)
+    {
+        // Arrange: application-assigned keys so the conflict match column is present in the source on
+        // every provider (Postgres/SQLite ON CONFLICT and SQL Server/Oracle MERGE alike).
+        var entities = new List<TestEntityWithGuidId>
+        {
+            new() { TestRun = _run, Id = Guid.NewGuid(), Name = $"{_run}_Original1" },
+            new() { TestRun = _run, Id = Guid.NewGuid(), Name = $"{_run}_Original2" }
+        };
+
+        await _context.ExecuteBulkInsertAsync(entities);
+
+        // Mutate locally, then re-insert with an Update expression that resolves to NO columns
+        // (an empty object initializer => a MemberInit with zero bindings), the shape an all-key entity
+        // produces. Before the fix this emitted an empty "DO UPDATE SET" / "WHEN MATCHED ... UPDATE SET"
+        // and failed with a syntax error; it must now degrade to insert-only / DO NOTHING.
+        foreach (var entity in entities)
+        {
+            entity.Name = $"Changed_{entity.Name}";
+        }
+
+        await _context.InsertWithStrategyAsync(strategy, entities,
+            onConflict: new OnConflictOptions<TestEntityWithGuidId>
+            {
+                Update = (inserted, excluded) => new TestEntityWithGuidId { },
+            });
+
+        // Assert: no duplicate rows, and the stored rows keep their ORIGINAL names (nothing was updated).
+        var stored = await _context.Set<TestEntityWithGuidId>()
+            .Where(x => x.TestRun == _run)
+            .AsNoTracking()
+            .ToListAsync();
+        stored.Should().HaveCount(2);
+        stored.Select(x => x.Name).Should().BeEquivalentTo($"{_run}_Original1", $"{_run}_Original2");
     }
 
     [SkippableTheory]


### PR DESCRIPTION
## Problem

When an `OnConflictOptions<T>.Update` expression resolves to **zero columns**, PhenX
generates syntactically invalid SQL. The simplest trigger is an entity that is nothing
but its primary key (no non-key column to overwrite), where the update expression is an
empty member-init (`new T { }`) — a `MemberInitExpression` with no bindings, which
`GetUpdates` correctly yields as an empty set.

The generated clause is then empty:

- **PostgreSQL / SQLite / MySQL** (`SqlDialectBuilder`): `... ON CONFLICT (...) DO UPDATE SET`
  with nothing after `SET` → PostgreSQL `42601`, SQLite `near ";": syntax error`.
- **SQL Server** (`SqlServerDialectBuilder`): `WHEN MATCHED THEN UPDATE SET` with an empty
  assignment list → invalid MERGE.
- **Oracle** (`OracleDialectBuilder`): already threw `InvalidOperationException` for this
  case, so it failed loudly rather than silently, but still could not perform the upsert.

This shows up in real use when bulk-upserting a table whose entity has no non-key columns
(e.g. a pure association / all-key table): inserting works, but the on-conflict upsert
blows up.

## Fix

When the resolved update column set is empty, there is nothing to update on a match, so
degrade to an insert-only upsert instead of emitting an empty assignment clause:

- Base dialect → `ON CONFLICT DO NOTHING`.
- SQL Server / Oracle MERGE → omit the `WHEN MATCHED` clause (an insert-only MERGE is valid).

This also makes Oracle consistent with the other providers (insert-only instead of throwing).
The normal, non-empty update path is unchanged.

## Test

`MergeTestsBase.InsertEntities_WithEmptyUpdate_DoesNothingOnConflict` inserts rows with
application-assigned keys, mutates them locally, then re-inserts with an empty-update
expression (`(inserted, excluded) => new TestEntityWithGuidId { }`). It asserts the
re-insert commits, produces no duplicates, and leaves the stored rows' original values
intact. Runs across every provider via the existing `MergeTests*` subclasses.
